### PR TITLE
Disable localization branch name in workflow

### DIFF
--- a/.github/workflows/download-workflows.yml
+++ b/.github/workflows/download-workflows.yml
@@ -21,7 +21,7 @@ jobs:
           upload_sources: false
           upload_translations: false
           download_translations: true
-          localization_branch_name: l10n_crowdin_translations
+          # localization_branch_name: l10n_crowdin_translations
 
           create_pull_request: false
           # pull_request_title: 'New Crowdin translations'


### PR DESCRIPTION
Comment out localization_branch_name in workflow.